### PR TITLE
Feature/add attendance post endpoint

### DIFF
--- a/app/backend/key/helpers.py
+++ b/app/backend/key/helpers.py
@@ -7,3 +7,19 @@ def isValidDateTime(text):
         return True
     except ValueError:
         return False
+
+# Determines if string is valid time
+def isValidTime(text):
+    try:
+        datetime.datetime.strptime(text, '%H:%M:%S')
+        return True
+    except ValueError:
+        return False
+
+# Returns current date in format YYYY-mm-dd
+def getCurrentDate():
+    return datetime.datetime.now().date()
+
+# Returns current time in format HH:MM:SS
+def getCurrentTime():
+    return datetime.datetime.now().time()

--- a/app/backend/key/models.py
+++ b/app/backend/key/models.py
@@ -6,6 +6,8 @@
 #   * Remove `managed = False` lines if you wish to allow Django to create, modify, and delete the table
 # Feel free to rename the models, but don't rename db_table values or field names.
 from django.db import models
+from .helpers import getCurrentDate, getCurrentTime
+import datetime
 
 
 class Activity(models.Model):
@@ -35,8 +37,8 @@ class Alert(models.Model):
 
 class AttendanceItems(models.Model):
     student_id = models.IntegerField(blank=True, null=True)
-    date = models.DateField(blank=True, null=True)
-    time = models.TimeField(blank=True, null=True)
+    date = models.DateField(blank=True, null=True, default=getCurrentDate)
+    time = models.TimeField(blank=True, null=True, default=getCurrentTime)
     activity_id = models.IntegerField(blank=True, null=True)
     visit_number = models.IntegerField(blank=True, null=True)
     id = models.AutoField(primary_key=True, unique=True)

--- a/app/backend/key/models.py
+++ b/app/backend/key/models.py
@@ -37,8 +37,8 @@ class Alert(models.Model):
 
 class AttendanceItems(models.Model):
     student_id = models.IntegerField(blank=True, null=True)
-    date = models.DateField(blank=True, null=True, default=getCurrentDate)
-    time = models.TimeField(blank=True, null=True, default=getCurrentTime)
+    date = models.DateField(default=getCurrentDate)
+    time = models.TimeField(default=getCurrentTime)
     activity_id = models.IntegerField(blank=True, null=True)
     visit_number = models.IntegerField(blank=True, null=True)
     id = models.AutoField(primary_key=True, unique=True)

--- a/app/backend/key/views/attendance.py
+++ b/app/backend/key/views/attendance.py
@@ -21,15 +21,15 @@ class Attendance(APIView):
             return False
         return True
 
-    # Validate input for the PATCH request of this endpoint - should reference a valid key
-    def validatePatch(self, request):
+    # Validate input for the DELETE request of this endpoint - should reference a valid key
+    def validateDelete(self, request):
         if not 'key' in request.query_params:
             return False
         try:
             AttendanceItems.objects.get(pk=request.query_params['key'])
         except:
             return False
-        return True    
+        return True
 
     # Validate input for POST request of this endpoint - checks student_id and activity_id are present and valid
     # If timestamps are provided, validates they are in the correct format
@@ -44,9 +44,9 @@ class Attendance(APIView):
             Activity.objects.get(activity_id=request.data['activity_id'])
         except:
             return False
-        if 'date' in request.data and not isValidDateTime(request.data['date']):
+        if 'date' in request.data and request.data['date'] != '' and not isValidDateTime(request.data['date']):
             return False
-        if 'time' in request.data and not isValidTime(request.data['time']):
+        if 'time' in request.data and request.data['date'] != '' and not isValidTime(request.data['time']):
             return False
         return True
 
@@ -65,17 +65,13 @@ class Attendance(APIView):
         serializer = AttendanceItemSerializer(items, many=True)
         return Response(serializer.data, content_type='application/json')
 
-    def patch(self, request):
-        if not self.validatePatch(request):
+    def delete(self, request):
+        if not self.validateDelete(request):
             return Response({'error':'Invalid Parameters'}, status='400')
 
         attendanceItem = AttendanceItems.objects.get(pk=request.query_params['key'])
-        serializer = AttendanceItemSerializer(attendanceItem, data=request.data)
-
-        if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        attendanceItem.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     def post(self, request):
         if not self.validatePost(request):

--- a/app/backend/key/views/attendance.py
+++ b/app/backend/key/views/attendance.py
@@ -80,5 +80,5 @@ class Attendance(APIView):
         serializer = AttendanceItemSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
-            return Response(serializer.data)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.error, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Associated with #33 

- Created POST /api/attendance, requires "student_id" and "activity_id" in request with optional "date" and "time", which are generated by default if unpopulated.

- Changed PATCH /api/attendance to DELETE since checking/unchecking attendance items will always add/delete items from dailyattendance, not modify an existing item.

- Originally, adding unit tests was going to be a part of this issue, however set up for tests is a bit more complicated and I'll be creating a separate issue to continue working on that. 